### PR TITLE
Added a link flag to support pointer nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ class BlockEntry {
   async final () {
     const key = this.tree.keyEncoding ? this.tree.keyEncoding.decode(this.key) : this.key
     const value = this.value && (this.tree.valueEncoding ? this.tree.valueEncoding.decode(this.value) : this.value)
-    if (this.link) {
+    if (this.link && !this.tree.options.noResolve) {
       const node = await this.tree.get(value)
       return {
         seq: this.seq,
@@ -447,6 +447,7 @@ class Batch {
     this.options = options
     this.locked = null
     this.onseq = this.options.onseq || noop
+    this.noResolve = this.options.noResolve
   }
 
   ready () {

--- a/index.js
+++ b/index.js
@@ -212,11 +212,19 @@ class BlockEntry {
   }
 
   async final () {
+    const key = this.tree.keyEncoding ? this.tree.keyEncoding.decode(this.key) : this.key
     const value = this.value && (this.tree.valueEncoding ? this.tree.valueEncoding.decode(this.value) : this.value)
-    if (this.link) return this.tree.get(value)
+    if (this.link) {
+      const node = await this.tree.get(value)
+      return {
+        seq: this.seq,
+        key,
+        value: node ? node.value : null
+      }
+    }
     return {
       seq: this.seq,
-      key: this.tree.keyEncoding ? this.tree.keyEncoding.decode(this.key) : this.key,
+      key,
       value
     }
   }
@@ -680,7 +688,7 @@ class Batch {
       key,
       value,
       link,
-      index: deflate(index),
+      index: deflate(index)
     }))
   }
 

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -405,6 +405,10 @@ function defineNode () {
       var len = encodings.bytes.encodingLength(obj.value)
       length += 1 + len
     }
+    if (defined(obj.link)) {
+      var len = encodings.bytes.encodingLength(obj.link)
+      length += 1 + len
+    }
     return length
   }
 
@@ -425,6 +429,11 @@ function defineNode () {
       encodings.bytes.encode(obj.value, buf, offset)
       offset += encodings.bytes.encode.bytes
     }
+    if (defined(obj.link)) {
+      buf[offset++] = 34
+      encodings.bytes.encode(obj.link, buf, offset)
+      offset += encodings.bytes.encode.bytes
+    }
     encode.bytes = offset - oldOffset
     return buf
   }
@@ -437,7 +446,8 @@ function defineNode () {
     var obj = {
       index: null,
       key: null,
-      value: null
+      value: null,
+      link: null
     }
     var found0 = false
     var found1 = false
@@ -463,6 +473,10 @@ function defineNode () {
         break
         case 3:
         obj.value = encodings.bytes.decode(buf, offset)
+        offset += encodings.bytes.decode.bytes
+        break
+        case 4:
+        obj.link = encodings.bytes.decode(buf, offset)
         offset += encodings.bytes.decode.bytes
         break
         default:

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -406,7 +406,7 @@ function defineNode () {
       length += 1 + len
     }
     if (defined(obj.link)) {
-      var len = encodings.bytes.encodingLength(obj.link)
+      var len = encodings.bool.encodingLength(obj.link)
       length += 1 + len
     }
     return length
@@ -430,9 +430,9 @@ function defineNode () {
       offset += encodings.bytes.encode.bytes
     }
     if (defined(obj.link)) {
-      buf[offset++] = 34
-      encodings.bytes.encode(obj.link, buf, offset)
-      offset += encodings.bytes.encode.bytes
+      buf[offset++] = 32
+      encodings.bool.encode(obj.link, buf, offset)
+      offset += encodings.bool.encode.bytes
     }
     encode.bytes = offset - oldOffset
     return buf
@@ -447,7 +447,7 @@ function defineNode () {
       index: null,
       key: null,
       value: null,
-      link: null
+      link: false
     }
     var found0 = false
     var found1 = false
@@ -476,8 +476,8 @@ function defineNode () {
         offset += encodings.bytes.decode.bytes
         break
         case 4:
-        obj.link = encodings.bytes.decode(buf, offset)
-        offset += encodings.bytes.decode.bytes
+        obj.link = encodings.bool.decode(buf, offset)
+        offset += encodings.bool.decode.bytes
         break
         default:
         offset = skip(prefix & 7, buf, offset)

--- a/schema.proto
+++ b/schema.proto
@@ -21,6 +21,7 @@ message Node {
   required bytes index = 1;
   required bytes key = 2;
   optional bytes value = 3;
+  optional bytes link = 4;
 }
 
 message Extension {

--- a/schema.proto
+++ b/schema.proto
@@ -21,7 +21,7 @@ message Node {
   required bytes index = 1;
   required bytes key = 2;
   optional bytes value = 3;
-  optional bytes link = 4;
+  optional bool link = 4;
 }
 
 message Extension {

--- a/test/all.js
+++ b/test/all.js
@@ -158,3 +158,19 @@ tape('test all short iterators', async function (t) {
     return true
   }
 })
+
+tape('can create block pointers with the link flag', async function (t) {
+  const db = create({
+    keyEncoding: 'utf-8',
+    valueEncoding: 'utf-8'
+  })
+
+  await db.put('hello', 'world')
+  await db.put('pointer', 'hello', { link: true })
+
+  const node = await db.get('pointer')
+  t.same(node.key, 'pointer')
+  t.same(node.value, 'world')
+
+  t.end()
+})

--- a/test/all.js
+++ b/test/all.js
@@ -174,3 +174,19 @@ tape('can create block pointers with the link flag', async function (t) {
 
   t.end()
 })
+
+tape('getting a pointer with the noResolve flag returns the pointer block', async function (t) {
+  const db = create({
+    keyEncoding: 'utf-8',
+    valueEncoding: 'utf-8'
+  })
+
+  await db.put('hello', 'world')
+  await db.put('pointer', 'hello', { link: true })
+
+  const node = await db.get('pointer', { noResolve: true })
+  t.same(node.key, 'pointer')
+  t.same(node.value, 'hello')
+
+  t.end()
+})


### PR DESCRIPTION
Setting the `link` flag to `true` marks a Node as a "pointer": the value is a key which should be resolved (via a second `get`) before the Node is returned.

This is useful for indexing, as you often want to store a large record once, but index it on various fields, with the field records being pointers to the original.