### PR TITLE
Use a Promises-only Hypercore API with hypercore-promisifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -707,10 +707,12 @@ class Batch {
     }))
   }
 
-  _appendBatch (raw) {
-    const prom = this.tree.feed.append(raw)
-    this._unlock()
-    return prom
+  async _appendBatch (raw) {
+    try {
+      await this.tree.feed.append(raw)
+    } finally {
+      this._unlock()
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "codecs": "^2.1.0",
+    "hypercore-promisifier": "^1.0.1",
     "mutexify": "^1.3.1",
     "protocol-buffers-encodings": "^1.1.0",
     "streamx": "^2.6.6"


### PR DESCRIPTION
With the hypercore-promisifier module, and `feed` passed into the constructor will be wrapped in a Promises API.