### PR TITLE
Read metadata when creating from existing feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ await subDb.get('b')
 
 Current version.
 
+#### `metadata = await db.getMetadata()`
+
+Get the metadata, if it was set with `opts.metadata` when creating the hyperbee. The metadata is stored at the start of the underlying feed.
+
 #### `await db.ready()`
 
 Makes sure internal state is loaded. Call this once before checking the version if you haven't called any of the other APIs.

--- a/index.js
+++ b/index.js
@@ -290,14 +290,22 @@ class HyperBee {
     return new Promise((resolve, reject) => {
       this.feed.ready(err => {
         if (err) return reject(err)
-        if (this.feed.length > 0 || !this.feed.writable) return resolve()
-        this.feed.append(Header.encode({
-          protocol: 'hyperbee',
-          metadata: this.metadata
-        }), (err) => {
-          if (err) return reject(err)
-          resolve()
-        })
+        if (this.feed.length > 0 || !this.feed.writable) {
+          this.feed.get(0, (err, data) => {
+            if (err) return reject(err)
+            const header = Header.decode(data)
+            this.metadata = header.metadata
+            return resolve()
+          })
+        } else {
+          this.feed.append(Header.encode({
+            protocol: 'hyperbee',
+            metadata: this.metadata
+          }), (err) => {
+            if (err) return reject(err)
+            resolve()
+          })
+        }
       })
     })
   }

--- a/index.js
+++ b/index.js
@@ -290,22 +290,27 @@ class HyperBee {
     return new Promise((resolve, reject) => {
       this.feed.ready(err => {
         if (err) return reject(err)
-        if (this.feed.length > 0 || !this.feed.writable) {
-          this.feed.get(0, (err, data) => {
-            if (err) return reject(err)
-            const header = Header.decode(data)
-            this.metadata = header.metadata
-            return resolve()
-          })
-        } else {
-          this.feed.append(Header.encode({
-            protocol: 'hyperbee',
-            metadata: this.metadata
-          }), (err) => {
-            if (err) return reject(err)
-            resolve()
-          })
-        }
+        if (this.feed.length > 0 || !this.feed.writable) return resolve()
+        this.feed.append(Header.encode({
+          protocol: 'hyperbee',
+          metadata: this.metadata
+        }), (err) => {
+          if (err) return reject(err)
+          resolve()
+        })
+      })
+    })
+  }
+
+  retrieveMetadata () {
+    return new Promise((resolve, reject) => {
+      if (this.metadata !== null) resolve(this.metadata)
+
+      this.feed.get(0, (err, data) => {
+        if (err) reject(err)
+        const header = Header.decode(data)
+        this.metadata = header.metadata
+        resolve(this.metadata)
       })
     })
   }

--- a/index.js
+++ b/index.js
@@ -302,12 +302,12 @@ class HyperBee {
     })
   }
 
-  retrieveMetadata () {
+  getMetadata () {
     return new Promise((resolve, reject) => {
-      if (this.metadata !== null) resolve(this.metadata)
+      if (this.metadata !== null) return resolve(this.metadata)
 
       this.feed.get(0, (err, data) => {
-        if (err) reject(err)
+        if (err) return reject(err)
         const header = Header.decode(data)
         this.metadata = header.metadata
         resolve(this.metadata)


### PR DESCRIPTION
Currently the metadata field is not filled when the hyperbee is created from an existing non-writable feed. This commit retrieves the header from the feed, and sets the metadata field. This would cause the hyperbee to not resolve until the first feed entry is loaded, but one could argue that the tree is not really ready when there is no header. It might make sense to also check if the protocol is set to `hyperbee`.