### PR TITLE
Sub and checkouts pass _ready opt

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,11 +286,13 @@ class HyperBee {
     return this._ready
   }
 
-  _open () {
-    return new Promise((resolve, reject) => {
+  async _open () {
+    const release = !this.lock.locked ? await this.lock() : null
+    await new Promise((resolve, reject) => {
       this.feed.ready(err => {
         if (err) return reject(err)
         if (this.feed.length > 0 || !this.feed.writable) return resolve()
+        console.log('APPENDING IN OPEN')
         this.feed.append(Header.encode({
           protocol: 'hyperbee',
           metadata: this.metadata
@@ -300,6 +302,7 @@ class HyperBee {
         })
       })
     })
+    if (release) release()
   }
 
   get version () {

--- a/index.js
+++ b/index.js
@@ -292,7 +292,6 @@ class HyperBee {
       this.feed.ready(err => {
         if (err) return reject(err)
         if (this.feed.length > 0 || !this.feed.writable) return resolve()
-        console.log('APPENDING IN OPEN')
         this.feed.append(Header.encode({
           protocol: 'hyperbee',
           metadata: this.metadata

--- a/index.js
+++ b/index.js
@@ -277,7 +277,7 @@ class HyperBee {
 
     this._sub = !!opts._sub
     this._checkout = opts.checkout || 0
-    this._ready = null
+    this._ready = opts._ready || null
   }
 
   ready () {
@@ -287,7 +287,6 @@ class HyperBee {
   }
 
   async _open () {
-    const release = !this.lock.locked ? await this.lock() : null
     await new Promise((resolve, reject) => {
       this.feed.ready(err => {
         if (err) return reject(err)
@@ -301,7 +300,6 @@ class HyperBee {
         })
       })
     })
-    if (release) release()
   }
 
   get version () {
@@ -420,6 +418,7 @@ class HyperBee {
 
   checkout (version) {
     return new HyperBee(this.feed, {
+      _ready: this.ready(),
       sep: this.sep,
       checkout: version,
       extension: this.extension,
@@ -439,6 +438,7 @@ class HyperBee {
 
     return new HyperBee(this.feed, {
       _sub: true,
+      _ready: this.ready(),
       sep: this.sep,
       lock: this.lock,
       checkout: this._checkout,

--- a/index.js
+++ b/index.js
@@ -286,8 +286,8 @@ class HyperBee {
     return this._ready
   }
 
-  async _open () {
-    await new Promise((resolve, reject) => {
+  _open () {
+    return new Promise((resolve, reject) => {
       this.feed.ready(err => {
         if (err) return reject(err)
         if (this.feed.length > 0 || !this.feed.writable) return resolve()


### PR DESCRIPTION
Since each sub-database is a separate Hyperbee, a _ready Promise needs to be passed in order to prevent appending the Header several times.