### PR TITLE
Add readonly constructor option

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ class HyperBee {
   async _open () {
     await this.feed.ready()
     if (this.feed.length > 0 || !this.feed.writable || this.writable === false) return
-    this.writable = this.writable ?? this.feed.writable
+    this.writable = true
     return this.feed.append(Header.encode({
       protocol: 'hyperbee',
       metadata: this.metadata
@@ -473,6 +473,7 @@ class Batch {
   }
 
   async lock () {
+    if (this.tree.writable === false) throw new Error('Tree is not writable')
     if (this.locked === null) this.locked = await this.tree.lock()
   }
 

--- a/index.js
+++ b/index.js
@@ -276,7 +276,7 @@ class HyperBee {
     this.metadata = opts.metadata || null
     this.lock = opts.lock || mutexify()
     this.sep = opts.sep || SEP
-    this.writable = opts.writable
+    this.readOnly = !!opts.readOnly
 
     this._sub = !!opts._sub
     this._checkout = opts.checkout || 0
@@ -291,8 +291,7 @@ class HyperBee {
 
   async _open () {
     await this.feed.ready()
-    if (this.feed.length > 0 || !this.feed.writable || this.writable === false) return
-    this.writable = true
+    if (this.feed.length > 0 || !this.feed.writable || this.readOnly) return
     return this.feed.append(Header.encode({
       protocol: 'hyperbee',
       metadata: this.metadata
@@ -473,7 +472,7 @@ class Batch {
   }
 
   async lock () {
-    if (this.tree.writable === false) throw new Error('Hyperbee is marked as non-writable')
+    if (this.tree.readOnly) throw new Error('Hyperbee is marked as read-only')
     if (this.locked === null) this.locked = await this.tree.lock()
   }
 

--- a/index.js
+++ b/index.js
@@ -276,7 +276,7 @@ class HyperBee {
     this.metadata = opts.metadata || null
     this.lock = opts.lock || mutexify()
     this.sep = opts.sep || SEP
-    this.readOnly = !!opts.readOnly
+    this.readonly = !!opts.readonly
 
     this._sub = !!opts._sub
     this._checkout = opts.checkout || 0
@@ -291,7 +291,7 @@ class HyperBee {
 
   async _open () {
     await this.feed.ready()
-    if (this.feed.length > 0 || !this.feed.writable || this.readOnly) return
+    if (this.feed.length > 0 || !this.feed.writable || this.readonly) return
     return this.feed.append(Header.encode({
       protocol: 'hyperbee',
       metadata: this.metadata
@@ -472,7 +472,7 @@ class Batch {
   }
 
   async lock () {
-    if (this.tree.readOnly) throw new Error('Hyperbee is marked as read-only')
+    if (this.tree.readonly) throw new Error('Hyperbee is marked as read-only')
     if (this.locked === null) this.locked = await this.tree.lock()
   }
 

--- a/index.js
+++ b/index.js
@@ -276,6 +276,7 @@ class HyperBee {
     this.metadata = opts.metadata || null
     this.lock = opts.lock || mutexify()
     this.sep = opts.sep || SEP
+    this.writable = opts.writable
 
     this._sub = !!opts._sub
     this._checkout = opts.checkout || 0
@@ -290,7 +291,8 @@ class HyperBee {
 
   async _open () {
     await this.feed.ready()
-    if (this.feed.length > 0 || !this.feed.writable) return
+    if (this.feed.length > 0 || !this.feed.writable || this.writable === false) return
+    this.writable = this.writable ?? this.feed.writable
     return this.feed.append(Header.encode({
       protocol: 'hyperbee',
       metadata: this.metadata

--- a/index.js
+++ b/index.js
@@ -473,7 +473,7 @@ class Batch {
   }
 
   async lock () {
-    if (this.tree.writable === false) throw new Error('Tree is not writable')
+    if (this.tree.writable === false) throw new Error('Hyperbee is marked as non-writable')
     if (this.locked === null) this.locked = await this.tree.lock()
   }
 

--- a/test/all.js
+++ b/test/all.js
@@ -267,3 +267,14 @@ tape('setting writable flag to false disables header write', async t => {
   t.false(db.writable)
   t.end()
 })
+
+tape('cannot append to non-writable db', async t => {
+  const db = create({ writable: false })
+  await db.ready()
+  try {
+    await db.append('hello', 'world')
+  } catch (err) {
+    t.true(err)
+  }
+  t.end()
+})

--- a/test/all.js
+++ b/test/all.js
@@ -261,15 +261,15 @@ tape('multiple levels of sub, entries outside sub', async t => {
 })
 
 tape('setting writable flag to false disables header write', async t => {
-  const db = create({ writable: false })
+  const db = create({ readOnly: true })
   await db.ready()
   t.same(db.feed.length, 0)
-  t.false(db.writable)
+  t.true(db.readOnly)
   t.end()
 })
 
 tape('cannot append to non-writable db', async t => {
-  const db = create({ writable: false })
+  const db = create({ readOnly: true })
   await db.ready()
   try {
     await db.append('hello', 'world')

--- a/test/all.js
+++ b/test/all.js
@@ -261,15 +261,15 @@ tape('multiple levels of sub, entries outside sub', async t => {
 })
 
 tape('setting read-only flag to false disables header write', async t => {
-  const db = create({ readOnly: true })
+  const db = create({ readonly: true })
   await db.ready()
   t.same(db.feed.length, 0)
-  t.true(db.readOnly)
+  t.true(db.readonly)
   t.end()
 })
 
 tape('cannot append to read-only db', async t => {
-  const db = create({ readOnly: true })
+  const db = create({ readonly: true })
   await db.ready()
   try {
     await db.append('hello', 'world')

--- a/test/all.js
+++ b/test/all.js
@@ -259,3 +259,11 @@ tape('multiple levels of sub, entries outside sub', async t => {
 
   t.end()
 })
+
+tape('setting writable flag to false disables header write', async t => {
+  const db = create({ writable: false })
+  await db.ready()
+  t.same(db.feed.length, 0)
+  t.false(db.writable)
+  t.end()
+})

--- a/test/all.js
+++ b/test/all.js
@@ -260,7 +260,7 @@ tape('multiple levels of sub, entries outside sub', async t => {
   t.end()
 })
 
-tape('setting writable flag to false disables header write', async t => {
+tape('setting read-only flag to false disables header write', async t => {
   const db = create({ readOnly: true })
   await db.ready()
   t.same(db.feed.length, 0)
@@ -268,7 +268,7 @@ tape('setting writable flag to false disables header write', async t => {
   t.end()
 })
 
-tape('cannot append to non-writable db', async t => {
+tape('cannot append to read-only db', async t => {
   const db = create({ readOnly: true })
   await db.ready()
   try {


### PR DESCRIPTION
Adds a `readonly` constructor option that when `true` will disable writing the Header + any appends.