### PR TITLE
Add de-promisifying getter for feed property 

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -1,6 +1,8 @@
 const tape = require('tape')
 const { create, collect } = require('./helpers')
 
+const Hyperbee = require('..')
+
 tape('out of bounds iterator', async function (t) {
   const db = create()
 
@@ -276,5 +278,13 @@ tape('cannot append to read-only db', async t => {
   } catch (err) {
     t.true(err)
   }
+  t.end()
+})
+
+tape('feed is unwrapped in getter', async t => {
+  const feed = require('hypercore')(require('random-access-memory'))
+  const db = new Hyperbee(feed)
+  await db.ready()
+  t.same(feed, db.feed)
   t.end()
 })


### PR DESCRIPTION
Hyperbee internally promisifies its feed using `hypercore-promisifier`, but then `db.feed` is set to the promisified version. One would expect the feed passed into the constructor to be equal to `db.feed`.

This PR adds a `db.feed` getter, which unwraps the internal feed.

Relevant issue on `hypercore-promisifier`: https://github.com/andrewosh/hypercore-promisifier/issues/1