### PR TITLE
Check tree extension in Batch.get

### DIFF
--- a/index.js
+++ b/index.js
@@ -536,7 +536,7 @@ class Batch {
 
   async get (key) {
     if (this.keyEncoding) key = enc(this.keyEncoding, key)
-    if (this.options.extension !== false) this.options.onwait = this._onwait.bind(this, key)
+    if (this.tree.extension !== null && this.options.extension !== false) this.options.onwait = this._onwait.bind(this, key)
 
     let node = await this.getRoot()
     if (!node) return null


### PR DESCRIPTION
If a Hyperbee has extensions disabled, a `Batch.get` will still use the extension unless it's constructed with `{ extension: false }`. It should instead consult the tree.