### PR TITLE
Fixed checkout/sub behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,7 +304,7 @@ class HyperBee {
     this._checkout = opts.checkout || 0
     this._ready = opts._ready || null
 
-    if (this.prefix) this.keyEncoding = prefixEncoding(this.prefix, this.keyEncoding)
+    if (this.prefix && !this._checkout) this.keyEncoding = prefixEncoding(this.prefix, this.keyEncoding)
   }
 
   get feed () {
@@ -442,6 +442,7 @@ class HyperBee {
     return new HyperBee(this._feed, {
       _ready: this.ready(),
       sep: this.sep,
+      prefix: this.prefix,
       checkout: version,
       extension: this.extension,
       keyEncoding: this.keyEncoding,

--- a/test/all.js
+++ b/test/all.js
@@ -346,7 +346,32 @@ tape('read stream on sub checkout returns only sub keys', async t => {
   for await (const { key } of checkout.createReadStream()) {
     keys.push(key)
   }
-  console.log('keys:', keys)
+
+  t.same(keys.length, 2)
+  t.same(keys[0], 'sa')
+  t.same(keys[1], 'sb')
+
+  t.end()
+})
+
+tape('read stream on double sub checkout', async t => {
+  t.plan(3)
+
+  const db = create({ sep: '!', keyEncoding: 'utf-8' })
+  const sub = db.sub('sub')
+
+  await db.put('a', 'a')
+  await sub.put('sa', 'sa')
+  await sub.put('sb', 'sb')
+
+  const checkout = sub.snapshot().snapshot()
+
+  await db.put('b', 'b')
+
+  const keys = []
+  for await (const { key } of checkout.createReadStream()) {
+    keys.push(key)
+  }
 
   t.same(keys.length, 2)
   t.same(keys[0], 'sa')

--- a/test/all.js
+++ b/test/all.js
@@ -328,6 +328,33 @@ tape('sub with a key that starts with 0xff', async t => {
   t.end()
 })
 
+tape('read stream on sub checkout returns only sub keys', async t => {
+  t.plan(3)
+
+  const db = create({ sep: '!', keyEncoding: 'utf-8' })
+  const sub = db.sub('sub')
+
+  await db.put('a', 'a')
+  await sub.put('sa', 'sa')
+  await sub.put('sb', 'sb')
+
+  const checkout = sub.snapshot()
+
+  await db.put('b', 'b')
+
+  const keys = []
+  for await (const { key } of checkout.createReadStream()) {
+    keys.push(key)
+  }
+  console.log('keys:', keys)
+
+  t.same(keys.length, 2)
+  t.same(keys[0], 'sa')
+  t.same(keys[1], 'sb')
+
+  t.end()
+})
+
 tape('setting read-only flag to false disables header write', async t => {
   const db = create({ readonly: true })
   await db.ready()

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const { createRange, collect, insertRange } = require('./helpers')
+const { create, createRange, collect, insertRange } = require('./helpers')
 
 test('basic diff', async function (t) {
   const db = await createRange(10)
@@ -32,6 +32,30 @@ test('bigger diff', async function (t) {
     { left: { seq: 13, key: '10', value: null }, right: null },
     { left: { seq: 14, key: '11', value: null }, right: null }
   ])
+
+  t.end()
+})
+
+test('diff stream on sub + checkout', async function (t) {
+  const db = create({ sep: '!', keyEncoding: 'utf-8' })
+  const sub = db.sub('sub')
+
+  await db.put('a', 'a')
+  await sub.put('sa', 'sa')
+  const v1 = sub.version
+  await sub.put('sb', 'sb')
+  const v2 = sub.version
+  await db.put('b', 'b')
+  await sub.put('sc', 'sc')
+
+  const entries1 = await collect(sub.checkout(v2).createDiffStream(v1))
+  const entries2 = await collect(sub.createDiffStream(v1))
+
+  t.same(entries1.length, 1)
+  t.same(entries2.length, 2)
+  t.same(entries1[0].left.key, 'sb')
+  t.same(entries2[0].left.key, 'sb')
+  t.same(entries2[1].left.key, 'sc')
 
   t.end()
 })


### PR DESCRIPTION
Fixes a bug where calling `checkout` on a `sub` will lead to incorrect iteration results on all iterators because the `keyEncoding` is recomputed inside the checkout. Instead, the checkout should use the parent's `keyEncoding`.