### PR TITLE
Fix checkout/sub bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,7 +304,9 @@ class HyperBee {
     this._checkout = opts.checkout || 0
     this._ready = opts._ready || null
 
-    if (this.prefix && !this._checkout) this.keyEncoding = prefixEncoding(this.prefix, this.keyEncoding)
+    if (this.prefix && opts._sub && !opts._checkout) {
+      this.keyEncoding = prefixEncoding(this.prefix, this.keyEncoding)
+    }
   }
 
   get feed () {
@@ -441,6 +443,7 @@ class HyperBee {
   checkout (version) {
     return new HyperBee(this._feed, {
       _ready: this.ready(),
+      _checkout: true,
       sep: this.sep,
       prefix: this.prefix,
       checkout: version,
@@ -465,6 +468,7 @@ class HyperBee {
 
     return new HyperBee(this._feed, {
       _ready: this.ready(),
+      _sub: true,
       prefix,
       sep: this.sep,
       lock: this.lock,

--- a/index.js
+++ b/index.js
@@ -304,7 +304,7 @@ class HyperBee {
     this._checkout = opts.checkout || 0
     this._ready = opts._ready || null
 
-    if (this.prefix && opts._sub && !opts._checkout) {
+    if (this.prefix && opts._sub) {
       this.keyEncoding = prefixEncoding(this.prefix, this.keyEncoding)
     }
   }
@@ -443,7 +443,7 @@ class HyperBee {
   checkout (version) {
     return new HyperBee(this._feed, {
       _ready: this.ready(),
-      _checkout: true,
+      _sub: false,
       sep: this.sep,
       prefix: this.prefix,
       checkout: version,


### PR DESCRIPTION
https://github.com/hypercore-protocol/hyperbee/pull/35 fixed a bug where `db.sub().checkout()` would not produce valid iterators, but unfortunately it introduced another bug where `db.checkout().sub()` would not have the correct `keyEncoding` on any sub databases.

This fix introduces two hidden constructor options (`_sub` and `_checkout`) that are used to distinguish between the following two cases:
1. If a Hyperbee is constructed with a prefix, and it is explicitly constructed from a `sub` call, then the `keyEncoding` should be updated
2. If a Hyperbee is constructed with a prefix, but as a result of a call to `checkout`, then the `keyEncoding` should not be updated.

Phew. Also added another sub/checkout/createDiffStream test for this scenario.