### PR TITLE
Fix extension disabling bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,6 +299,7 @@ class HyperBee {
     this.readonly = !!opts.readonly
     this.prefix = opts.prefix || null
 
+    this._disabledExtension = opts.extension === false
     this._unprefixedKeyEncoding = this.keyEncoding
     this._sub = !!this.prefix
     this._checkout = opts.checkout || 0
@@ -473,9 +474,9 @@ class HyperBee {
       sep: this.sep,
       lock: this.lock,
       checkout: this._checkout,
-      extension: this.extension,
       valueEncoding,
-      keyEncoding
+      keyEncoding,
+      extension: this._disabledExtension ? false : this.extension
     })
   }
 }

--- a/index.js
+++ b/index.js
@@ -448,8 +448,8 @@ class HyperBee {
       prefix: this.prefix,
       checkout: version,
       keyEncoding: this.keyEncoding,
-      valueEncoding: this.valueEncoding
-      extension: this.extension !== null : this.extension : false,
+      valueEncoding: this.valueEncoding,
+      extension: this.extension !== null ? this.extension : false
     })
   }
 
@@ -475,7 +475,7 @@ class HyperBee {
       checkout: this._checkout,
       valueEncoding,
       keyEncoding,
-      extension: this.extension !== null : this.extension : false
+      extension: this.extension !== null ? this.extension : false
     })
   }
 }

--- a/index.js
+++ b/index.js
@@ -299,7 +299,6 @@ class HyperBee {
     this.readonly = !!opts.readonly
     this.prefix = opts.prefix || null
 
-    this._disabledExtension = opts.extension === false
     this._unprefixedKeyEncoding = this.keyEncoding
     this._sub = !!this.prefix
     this._checkout = opts.checkout || 0
@@ -448,9 +447,9 @@ class HyperBee {
       sep: this.sep,
       prefix: this.prefix,
       checkout: version,
-      extension: this.extension,
       keyEncoding: this.keyEncoding,
       valueEncoding: this.valueEncoding
+      extension: this.extension !== null : this.extension : false,
     })
   }
 
@@ -476,7 +475,7 @@ class HyperBee {
       checkout: this._checkout,
       valueEncoding,
       keyEncoding,
-      extension: this._disabledExtension ? false : this.extension
+      extension: this.extension !== null : this.extension : false
     })
   }
 }


### PR DESCRIPTION
When the extension is disabled in the parent (via `extension: false`), sub databases will currently still attempt to register it, because this option is overridden.

This fix ensures that `extension: false` disables the extension in all sub databases as well.