### PR TITLE
Lazily insert header on first write

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,9 +315,7 @@ class HyperBee {
   }
 
   ready () {
-    if (this._ready !== null) return this._ready
-    this._ready = this._feed.ready()
-    return this._ready
+    return this._feed.ready()
   }
 
   get version () {

--- a/iterators/diff.js
+++ b/iterators/diff.js
@@ -75,7 +75,7 @@ class TreeIterator {
   }
 
   async open () {
-    const node = await this.db.getRoot()
+    const node = await this.db.getRoot(false)
     if (!node.keys.length) return
     const tree = new SubTree(node, null)
     if (this.seeking && !(await this._seek(tree))) return

--- a/iterators/history.js
+++ b/iterators/history.js
@@ -13,7 +13,7 @@ module.exports = class HistoryIterator {
   }
 
   async open () {
-    await this.db.getRoot() // does the update dance
+    await this.db.getRoot(false) // does the update dance
     this.gte = gte(this.options, this.db.version)
     this.lt = this.live ? Infinity : lt(this.options, this.db.version)
   }

--- a/iterators/range.js
+++ b/iterators/range.js
@@ -59,7 +59,7 @@ module.exports = class RangeIterator {
 
     this._nexting = true
 
-    let node = await this.db.getRoot()
+    let node = await this.db.getRoot(false)
     if (!node) {
       this._nexting = false
       return

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -52,7 +52,7 @@ async function createRange (start, end, opts = end) {
 }
 
 async function toString (tree) {
-  return require('tree-to-string')(await load(await tree.getRoot()))
+  return require('tree-to-string')(await load(await tree.getRoot(false)))
 
   async function load (node) {
     const res = { values: [], children: [] }


### PR DESCRIPTION
Right now we insert the header eagerly in `ready`. With this change, the header will be inserted before the first write operation instead.