### PR TITLE
onlyIfChanged: adds option to put only if value passed is different from value at key

### DIFF
--- a/index.js
+++ b/index.js
@@ -599,7 +599,7 @@ class Batch {
     const seq = this.tree._feed.length + this.length
     const target = new Key(seq, key)
 
-    let onlyIfChanged = !!(opts || this.options).onlyIfChanged
+    const onlyIfChanged = !!(opts || this.options).onlyIfChanged
 
     while (node.children.length) {
       stack.push(node)
@@ -620,7 +620,6 @@ class Batch {
             const block = await this.getBlock(node.keys[mid].seq)
             const same = (Buffer.compare(block.value, value) === 0)
             if (same) try { return block.final() } finally { this._unlockMaybe() }
-            else onlyIfChanged = false // so we don't duplicate work below
           }
 
           node.setKey(mid, target)

--- a/index.js
+++ b/index.js
@@ -617,8 +617,7 @@ class Batch {
           if (!this.overwrite) return this._unlockMaybe()
 
           if (onlyIfChanged) {
-            const seq = await this.getSeq(key)
-            const block = await this.getBlock(seq)
+            const block = await this.getBlock(node.keys[mid].seq)
             const same = (Buffer.compare(block.value, value) === 0)
             if (same) try { return block.final() } finally { this._unlockMaybe() }
             else onlyIfChanged = false // so we don't duplicate work below

--- a/test/all.js
+++ b/test/all.js
@@ -409,21 +409,18 @@ tape('feed is unwrapped in getter', async t => {
 })
 
 tape('put onlyIfChanged inserts only if existing value !== value', async t => {
-  const Hypercore = require('hypercore')
-  const feed = new Hypercore(require('random-access-memory'))
-  const db = new Hyperbee(feed)
-  await db.ready()
+  const db = create()
   const key = Buffer.from('key')
   const value = Buffer.from('value')
   await db.put(key, value)
   const fst = await db.get(key)
-  const fstlen = db._feed.length
+  const fstlen = db.feed.length
   await db.put(key, value, { onlyIfChanged: true })
   const snd = await db.get(key)
-  const sndlen = db._feed.length
+  const sndlen = db.feed.length
   await db.put(key, Buffer.from('va1ue'), { onlyIfChanged: true })
   const thd = await db.get(key)
-  const thdlen = db._feed.length
+  const thdlen = db.feed.length
   t.equals(fst.seq, snd.seq)
   t.equals(fstlen, sndlen)
   t.equals(snd.seq, thd.seq - 1)
@@ -432,10 +429,7 @@ tape('put onlyIfChanged inserts only if existing value !== value', async t => {
 })
 
 tape('batch put onlyIfChanged inserts only if existing value !== value', async t => {
-  const Hypercore = require('hypercore')
-  const feed = new Hypercore(require('random-access-memory'))
-  const db = new Hyperbee(feed)
-  await db.ready()
+  const db = create()
   const key = Buffer.from('key')
   const value = Buffer.from('value')
   const batch = db.batch()


### PR DESCRIPTION
This PR adds an `{ onlyIfChanged: Boolean }` option to `Hyperbee.put()` and `Hyperbee.batch().put()`, constraining puts at a key to only succeed if the existing value at the key is not the same (i.e. if the encoded binary values are not the same).