### PR TITLE
Adds Compare And Swap to Hyperbee

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Options include:
 ```
 
 ##### Compare And Swap (cas)
-You have the option to pass a `cas` function as an option to `put` that controls whether the `put` succeeds. Given `bee.put(key, value, { cas })`, `cas` is passed the current node (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ block. Then `put` succeeds only if `cas` returns `true` and fails otherwise.
+You have the option to pass a `cas` function as an option to `put` that controls whether the `put` succeeds. Given `bee.put(key, value, { cas })`, `cas` is passed the current node (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ node. Then `put` succeeds only if `cas` returns `true` and fails otherwise.
 
 ```js
 const cas = (prev, next) => prev.value !== next.value

--- a/README.md
+++ b/README.md
@@ -61,36 +61,98 @@ Options include:
 
 Note that currently read/diff streams sort based on the *encoded* value of the keys.
 
-#### `await db.put(key, [value])`
+#### `await db.put(key, [value], [options])`
 
 Insert a new key. Value can be optional. If you are inserting a series of data atomically,
 or you just have a batch of inserts/deletions available using a batch can be much faster
 than simply using a series of puts/dels on the db.
+
+Options include:
+
+```js
+{
+  cas (prev, next) { return true }
+}
+```
+
+##### Compare And Swap (cas)
+You have the option to pass a `cas` function as an option to `put` that controls whether the `put` succeeds. Given `bee.put(key, value, { cas })`, `cas` is passed the current block (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ block. Then `put` succeeds iff `cas` returns `true` and fails otherwise.
+
+```js
+const cas = (prev, next) => prev.value !== next.value
+const db = new Hyperbee(feed, { valueEncoding: 'utf8', valueEncoding: 'utf8' })
+await db.put('key', 'value')
+console.log(await db.get('key')) // { seq: 0, key: 'key', value: 'value' }
+await db.put('key', 'value', { cas })
+console.log(await db.get('key')) // { seq: 0, key: 'key', value: 'value' }
+await db.put('key', 'value*', { cas })
+console.log(await db.get('key')) // { seq: 1, key: 'key', value: 'value*' }
+```
 
 #### `{ seq, key, value } = await db.get(key)`
 
 Get a key, value. If the key does not exist, `null` is returned.
 `seq` is the hypercore version at which this key was inserted.
 
-#### `await db.del(key)`
+#### `await db.del(key, [options])`
 
 Delete a key
+
+Options include:
+
+```js
+{
+  cas (prev, next) { return true }
+}
+```
+
+##### Compare And Swap (cas)
+You can pass a `cas` function as an option to `del` that controls whether the `del` succeeds. Given `bee.del(key, { cas })`, `cas` is passed the current block (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ block, in this case the tombstone value `{ seq, key, value: null }`. Then `del` succeeds iff `cas` returns `true` and fails otherwise.
+
+```js
+const cas = (prev) => prev.value === 'value*'
+const db = new Hyperbee(feed, { valueEncoding: 'utf8', valueEncoding: 'utf8' })
+await db.put('key', 'value')
+console.log(await db.get('key')) // { seq: 0, key: 'key', value: 'value' }
+await db.del('key', { cas })
+console.log(await db.get('key')) // { seq: 0, key: 'key', value: 'value' }
+await db.put('key', 'value*', { cas })
+console.log(await db.get('key')) // { seq: 1, key: 'key', value: 'value*' }
+await db.del('key', { cas })
+console.log(await db.get('key')) // null
+```
 
 #### `batch = db.batch()`
 
 Make a new batch.
 
-#### `await batch.put(key, [value])`
+#### `await batch.put(key, [value], [options])`
 
 Insert a key into a batch.
+
+Options include:
+
+```js
+{
+  cas (prev, next) { return true } // see await db.put(key, value, { cas })
+}
+```
 
 #### `{ seq, key, value } = await batch.get(key)`
 
 Get a key, value out of a batch.
 
-#### `await batch.del(key)`
+#### `await batch.del(key, [options])`
 
 Delete a key into the batch.
+
+Options include:
+
+```js
+{
+  cas (prev, next) { return true } // see await db.del(key, { cas })
+}
+```
 
 #### `await batch.flush()`
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Options include:
 ```
 
 ##### Compare And Swap (cas)
-You have the option to pass a `cas` function as an option to `put` that controls whether the `put` succeeds. Given `bee.put(key, value, { cas })`, `cas` is passed the current block (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ block. Then `put` succeeds iff `cas` returns `true` and fails otherwise.
+You have the option to pass a `cas` function as an option to `put` that controls whether the `put` succeeds. Given `bee.put(key, value, { cas })`, `cas` is passed the current block (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ block. Then `put` succeeds only if `cas` returns `true` and fails otherwise.
 
 ```js
 const cas = (prev, next) => prev.value !== next.value
@@ -107,7 +107,7 @@ Options include:
 ```
 
 ##### Compare And Swap (cas)
-You can pass a `cas` function as an option to `del` that controls whether the `del` succeeds. Given `bee.del(key, { cas })`, `cas` is passed the current block (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ block, in this case the tombstone value `{ seq, key, value: null }`. Then `del` succeeds iff `cas` returns `true` and fails otherwise.
+You can pass a `cas` function as an option to `del` that controls whether the `del` succeeds. Given `bee.del(key, { cas })`, `cas` is passed the current block (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ block, in this case the tombstone value `{ seq, key, value: null }`. Then `del` succeeds succeeds only if `cas` returns `true` and fails otherwise.
 
 ```js
 const cas = (prev) => prev.value === 'value*'

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Options include:
 ```
 
 ##### Compare And Swap (cas)
-You have the option to pass a `cas` function as an option to `put` that controls whether the `put` succeeds. Given `bee.put(key, value, { cas })`, `cas` is passed the current block (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ block. Then `put` succeeds only if `cas` returns `true` and fails otherwise.
+You have the option to pass a `cas` function as an option to `put` that controls whether the `put` succeeds. Given `bee.put(key, value, { cas })`, `cas` is passed the current node (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ block. Then `put` succeeds only if `cas` returns `true` and fails otherwise.
 
 ```js
 const cas = (prev, next) => prev.value !== next.value
@@ -107,7 +107,7 @@ Options include:
 ```
 
 ##### Compare And Swap (cas)
-You can pass a `cas` function as an option to `del` that controls whether the `del` succeeds. Given `bee.del(key, { cas })`, `cas` is passed the current block (i.e. `{ seq, key, value }`) in `bee` at `key` and the next _tentative_ block, in this case the tombstone value `{ seq, key, value: null }`. Then `del` succeeds succeeds only if `cas` returns `true` and fails otherwise.
+You can pass a `cas` function as an option to `del` that controls whether the `del` succeeds. Given `bee.del(key, { cas })`, `cas` is passed the current node (i.e. `{ seq, key, value }`) in `bee` at `key`, and `del` succeeds only if `cas` returns `true` and fails otherwise.
 
 ```js
 const cas = (prev) => prev.value === 'value*'

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ You have the option to pass a `cas` function as an option to `put` that controls
 const cas = (prev, next) => prev.value !== next.value
 const db = new Hyperbee(feed, { valueEncoding: 'utf8', valueEncoding: 'utf8' })
 await db.put('key', 'value')
-console.log(await db.get('key')) // { seq: 0, key: 'key', value: 'value' }
+console.log(await db.get('key')) // { seq: 1, key: 'key', value: 'value' }
 await db.put('key', 'value', { cas })
-console.log(await db.get('key')) // { seq: 0, key: 'key', value: 'value' }
+console.log(await db.get('key')) // { seq: 1, key: 'key', value: 'value' }
 await db.put('key', 'value*', { cas })
-console.log(await db.get('key')) // { seq: 1, key: 'key', value: 'value*' }
+console.log(await db.get('key')) // { seq: 2, key: 'key', value: 'value*' }
 ```
 
 #### `{ seq, key, value } = await db.get(key)`
@@ -113,11 +113,11 @@ You can pass a `cas` function as an option to `del` that controls whether the `d
 const cas = (prev) => prev.value === 'value*'
 const db = new Hyperbee(feed, { valueEncoding: 'utf8', valueEncoding: 'utf8' })
 await db.put('key', 'value')
-console.log(await db.get('key')) // { seq: 0, key: 'key', value: 'value' }
+console.log(await db.get('key')) // { seq: 1, key: 'key', value: 'value' }
 await db.del('key', { cas })
-console.log(await db.get('key')) // { seq: 0, key: 'key', value: 'value' }
+console.log(await db.get('key')) // { seq: 1, key: 'key', value: 'value' }
 await db.put('key', 'value*', { cas })
-console.log(await db.get('key')) // { seq: 1, key: 'key', value: 'value*' }
+console.log(await db.get('key')) // { seq: 2, key: 'key', value: 'value*' }
 await db.del('key', { cas })
 console.log(await db.get('key')) // null
 ```

--- a/index.js
+++ b/index.js
@@ -581,14 +581,16 @@ class Batch {
   async cas (key, value, test, { compare } = {}) {
     compare = compare ?? _compare
     const raw = compare === _compare
-    test = (raw) ? enc(this.valueEncoding, test) : test
 
     const current = await this.get(key, { raw })
-    if (!current || !compare(test, current.value, { key, value })) return null
+    if (!current || !compare.bind(this)(test, current.value, { key, value })) return null
     await this.put(key, value)
     return (raw) ? current.final() : current
 
-    function _compare (t, c) { return Buffer.compare(t, c) === 0 }
+    function _compare (t, c) {
+      t = enc(this.valueEncoding, t)
+      return Buffer.compare(t, c) === 0
+    }
   }
 
   async put (key, value) {

--- a/index.js
+++ b/index.js
@@ -583,7 +583,7 @@ class Batch {
     const raw = compare === _compare
 
     const current = await this.get(key, { raw })
-    if (!current || !compare.bind(this)(test, current.value, { key, value })) return null
+    if (!current || !compare.bind(this)(test, current.value)) return null
     await this.put(key, value)
     return (raw) ? current.final() : current
 

--- a/index.js
+++ b/index.js
@@ -543,11 +543,9 @@ class Batch {
     return ite.next()
   }
 
-  async get (key, { raw } = {}) {
+  async get (key) {
     if (this.keyEncoding) key = enc(this.keyEncoding, key)
     if (this.tree.extension !== null && this.options.extension !== false) this.options.onwait = this._onwait.bind(this, key)
-
-    raw = raw ?? this.options?.raw
 
     let node = await this.getRoot(false)
     if (!node) return null
@@ -562,10 +560,7 @@ class Batch {
 
         c = Buffer.compare(key, await node.getKey(mid))
 
-        if (c === 0) {
-          const block = await this.getBlock(node.keys[mid].seq)
-          return (raw) ? block : block.final()
-        }
+        if (c === 0) return (await this.getBlock(node.keys[mid].seq)).final()
 
         if (c < 0) e = mid
         else s = mid + 1

--- a/test/all.js
+++ b/test/all.js
@@ -400,7 +400,8 @@ tape('cannot append to read-only db', async t => {
 })
 
 tape('feed is unwrapped in getter', async t => {
-  const feed = require('hypercore')(require('random-access-memory'))
+  const Hypercore = require('hypercore')
+  const feed = new Hypercore(require('random-access-memory'))
   const db = new Hyperbee(feed)
   await db.ready()
   t.same(feed, db.feed)

--- a/test/cas.js
+++ b/test/cas.js
@@ -1,0 +1,104 @@
+const tape = require('tape')
+const { create } = require('./helpers')
+
+tape('cas should put kv pair if comparator evals true, noop otherwise', async t => {
+  const key = 'key'
+  const value = 'value'
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, value + '^', value)
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, value, value + '^')
+    t.equals(snd, null)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const compare = (x, y) => x === y
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, value + '^', value, { compare })
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const compare = (x, y) => x === y
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, value, value + '^', { compare })
+    t.equals(snd, null)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, { value: value + '^' }, v)
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, v, { value: value + '^' })
+    t.equals(snd, null)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const v = { value }
+    const compare = (x, y) => JSON.stringify(x) === JSON.stringify(y)
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, { value: value + '^' }, v, { compare })
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const v = { value }
+    const compare = (x, y) => JSON.stringify(x) === JSON.stringify(y)
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, v, { value: value + '^' }, { compare })
+    t.equals(snd, null)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const db = create()
+    const k0 = Buffer.from(key)
+    const v0 = Buffer.from(value)
+    await db.put(k0, v0)
+    const fst = await db.get(k0)
+    const snd = await db.cas(k0, Buffer.from(value + '^'), v0)
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const db = create()
+    const k0 = Buffer.from(key)
+    const v0 = Buffer.from(value)
+    await db.put(k0, v0)
+    const fst = await db.get(k0)
+    const snd = await db.cas(k0, v0, Buffer.from(value + '^'))
+    t.equals(snd, null)
+    t.notDeepEquals(fst, snd)
+  }
+})

--- a/test/cas.js
+++ b/test/cas.js
@@ -1,226 +1,448 @@
 const tape = require('tape')
 const { create } = require('./helpers')
 
-tape('bee.cas should put kv pair if comparator evals true, noop otherwise', async t => {
+tape('bee.put({ cas }) succeds if cas(last, next) returns truthy', async t => {
   const key = 'key'
   const value = 'value'
 
   {
-    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const db = create()
+    const cas = (lst, nxt) => nxt.value !== lst.value
     await db.put(key, value)
     const fst = await db.get(key)
-    const snd = await db.cas(key, value + '^', value)
-    t.deepEquals(fst, snd)
-  }
-
-  {
-    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
-    await db.put(key, value)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, value, value + '^')
-    t.equals(snd, null)
-    t.notDeepEquals(fst, snd)
-  }
-
-  {
-    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
-    const compare = (x, y) => x === y
-    await db.put(key, value)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, value + '^', value, { compare })
-    t.deepEquals(fst, snd)
-  }
-
-  {
-    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
-    const compare = (x, y) => x === y
-    await db.put(key, value)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, value, value + '^', { compare })
-    t.equals(snd, null)
-    t.notDeepEquals(fst, snd)
-  }
-
-  {
-    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
-    const v = { value }
-    await db.put(key, v)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, { value: value + '^' }, v)
-    t.deepEquals(fst, snd)
-  }
-
-  {
-    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
-    const v = { value }
-    await db.put(key, v)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, v, { value: value + '^' })
-    t.equals(snd, null)
-    t.notDeepEquals(fst, snd)
-  }
-
-  {
-    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
-    const v = { value }
-    const compare = (x, y) => JSON.stringify(x) === JSON.stringify(y)
-    await db.put(key, v)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, { value: value + '^' }, v, { compare })
-    t.deepEquals(fst, snd)
-  }
-
-  {
-    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
-    const v = { value }
-    const compare = (x, y) => JSON.stringify(x) === JSON.stringify(y)
-    await db.put(key, v)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, v, { value: value + '^' }, { compare })
-    t.equals(snd, null)
+    await db.put(key, value + '^', { cas })
+    const snd = await db.get(key)
     t.notDeepEquals(fst, snd)
   }
 
   {
     const db = create()
-    const k0 = Buffer.from(key)
-    const v0 = Buffer.from(value)
-    await db.put(k0, v0)
-    const fst = await db.get(k0)
-    const snd = await db.cas(k0, Buffer.from(value + '^'), v0)
+    const cas = (lst, nxt) => nxt.value !== lst.value
+    await db.put(key, value)
+    const fst = await db.get(key)
+    await db.put(key, value, { cas })
+    const snd = await db.get(key)
     t.deepEquals(fst, snd)
   }
 
   {
-    const db = create()
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const cas = (lst, nxt) => nxt.value !== lst.value
+    await db.put(key, value)
+    const fst = await db.get(key)
+    await db.put(key, value + '^', { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const cas = (lst, nxt) => nxt.value !== lst.value
+    await db.put(key, value)
+    const fst = await db.get(key)
+    await db.put(key, value, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const cas = (lst, nxt) => JSON.stringify(lst.value) !== JSON.stringify(nxt.value)
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    await db.put(key, { value: value + '^' }, { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const cas = (lst, nxt) => JSON.stringify(lst.value) !== JSON.stringify(nxt.value)
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    await db.put(key, { value }, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'binary', valueEncoding: 'binary' })
+    const cas = (lst, nxt) => Buffer.compare(lst.value, nxt.value) !== 0
     const k0 = Buffer.from(key)
     const v0 = Buffer.from(value)
     await db.put(k0, v0)
     const fst = await db.get(k0)
-    const snd = await db.cas(k0, v0, Buffer.from(value + '^'))
-    t.equals(snd, null)
+    await db.put(k0, Buffer.from(value), { cas })
+    const snd = await db.get(k0)
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const db = create({ keyEncoding: 'binary', valueEncoding: 'binary' })
+    const cas = (lst, nxt) => Buffer.compare(lst.value, nxt.value) !== 0
+    const k0 = Buffer.from(key)
+    const v0 = Buffer.from(value)
+    await db.put(k0, v0)
+    const fst = await db.get(k0)
+    await db.put(k0, Buffer.from(value + '^'), { cas })
+    const snd = await db.get(k0)
     t.notDeepEquals(fst, snd)
   }
 })
 
-tape('bee.batch().cas() should put kv pair if comparator evals true, noop otherwise', async t => {
+tape('bee.batch().put({ cas }) succeds if cas(last, next) returns truthy', async t => {
   const key = 'key'
   const value = 'value'
 
   {
-    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const bee = create()
     const db = bee.batch()
+    const cas = (lst, nxt) => nxt.value !== lst.value
     await db.put(key, value)
     const fst = await db.get(key)
-    const snd = await db.cas(key, value + '^', value)
-    await db.flush()
-    t.deepEquals(fst, snd)
-  }
-
-  {
-    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
-    const db = bee.batch()
-    await db.put(key, value)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, value, value + '^')
-    await db.flush()
-    t.equals(snd, null)
-    t.notDeepEquals(fst, snd)
-  }
-
-  {
-    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
-    const db = bee.batch()
-    const compare = (x, y) => x === y
-    await db.put(key, value)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, value + '^', value, { compare })
-    await db.flush()
-    t.deepEquals(fst, snd)
-  }
-
-  {
-    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
-    const db = bee.batch()
-    const compare = (x, y) => x === y
-    await db.put(key, value)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, value, value + '^', { compare })
-    await db.flush()
-    t.equals(snd, null)
-    t.notDeepEquals(fst, snd)
-  }
-
-  {
-    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
-    const db = bee.batch()
-    const v = { value }
-    await db.put(key, v)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, { value: value + '^' }, v)
-    await db.flush()
-    t.deepEquals(fst, snd)
-  }
-
-  {
-    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
-    const db = bee.batch()
-    const v = { value }
-    await db.put(key, v)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, v, { value: value + '^' })
-    await db.flush()
-    t.equals(snd, null)
-    t.notDeepEquals(fst, snd)
-  }
-
-  {
-    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
-    const db = bee.batch()
-    const v = { value }
-    const compare = (x, y) => JSON.stringify(x) === JSON.stringify(y)
-    await db.put(key, v)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, { value: value + '^' }, v, { compare })
-    await db.flush()
-    t.deepEquals(fst, snd)
-  }
-
-  {
-    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
-    const db = bee.batch()
-    const v = { value }
-    const compare = (x, y) => JSON.stringify(x) === JSON.stringify(y)
-    await db.put(key, v)
-    const fst = await db.get(key)
-    const snd = await db.cas(key, v, { value: value + '^' }, { compare })
-    await db.flush()
-    t.equals(snd, null)
+    await db.put(key, value + '^', { cas })
+    const snd = await db.get(key)
     t.notDeepEquals(fst, snd)
   }
 
   {
     const bee = create()
     const db = bee.batch()
+    const cas = (lst, nxt) => nxt.value !== lst.value
+    await db.put(key, value)
+    const fst = await db.get(key)
+    await db.put(key, value, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const db = bee.batch()
+    const cas = (lst, nxt) => nxt.value !== lst.value
+    await db.put(key, value)
+    const fst = await db.get(key)
+    await db.put(key, value + '^', { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const db = bee.batch()
+    const cas = (lst, nxt) => nxt.value !== lst.value
+    await db.put(key, value)
+    const fst = await db.get(key)
+    await db.put(key, value, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const db = bee.batch()
+    const cas = (lst, nxt) => JSON.stringify(lst.value) !== JSON.stringify(nxt.value)
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    await db.put(key, { value: value + '^' }, { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const db = bee.batch()
+    const cas = (lst, nxt) => JSON.stringify(lst.value) !== JSON.stringify(nxt.value)
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    await db.put(key, { value }, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'binary' })
+    const db = bee.batch()
+    const cas = (lst, nxt) => Buffer.compare(lst.value, nxt.value) !== 0
     const k0 = Buffer.from(key)
     const v0 = Buffer.from(value)
     await db.put(k0, v0)
     const fst = await db.get(k0)
-    const snd = await db.cas(k0, Buffer.from(value + '^'), v0)
-    await db.flush()
+    await db.put(k0, Buffer.from(value), { cas })
+    const snd = await db.get(k0)
     t.deepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'binary' })
+    const db = bee.batch()
+    const cas = (lst, nxt) => Buffer.compare(lst.value, nxt.value) !== 0
+    const k0 = Buffer.from(key)
+    const v0 = Buffer.from(value)
+    await db.put(k0, v0)
+    const fst = await db.get(k0)
+    await db.put(k0, Buffer.from(value + '^'), { cas })
+    const snd = await db.get(k0)
+    t.notDeepEquals(fst, snd)
+  }
+})
+
+tape('bee.del({ cas }) succeds if cas(last, tomb) returns truthy', async t => {
+  const key = 'key'
+  const value = 'value'
+
+  {
+    const db = create()
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const cas = (lst) => lst.value === value
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+    t.equals(snd, null)
+  }
+
+  {
+    const db = create()
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const cas = (lst) => lst.value !== value
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+    t.notEquals(snd, null)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const cas = (lst) => lst.value === value
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+    t.equals(snd, null)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const cas = (lst) => lst.value !== value
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+    t.notEquals(snd, null)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const cas = (lst) => JSON.stringify(lst.value) === JSON.stringify(v)
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+    t.equals(snd, null)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const cas = (lst) => JSON.stringify(lst.value) !== JSON.stringify(v)
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+    t.notEquals(snd, null)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const cas = (lst) => JSON.stringify(lst.value) === JSON.stringify(v)
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+    t.equals(snd, null)
+  }
+
+  {
+    const db = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const cas = (lst) => JSON.stringify(lst.value) !== JSON.stringify(v)
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+    t.notEquals(snd, null)
+  }
+
+  {
+    const db = create({ keyEncoding: 'binary', valueEncoding: 'binary' })
+    const k0 = Buffer.from(key)
+    const v0 = Buffer.from(value)
+    await db.put(k0, v0)
+    const fst = await db.get(k0)
+    const cas = (lst, nxt) => Buffer.compare(lst.value, v0) === 0
+    await db.del(key, { cas })
+    const snd = await db.get(k0)
+    t.notDeepEquals(fst, snd)
+    t.equals(snd, null)
+  }
+
+  {
+    const db = create({ keyEncoding: 'binary', valueEncoding: 'binary' })
+    const k0 = Buffer.from(key)
+    const v0 = Buffer.from(value)
+    await db.put(k0, v0)
+    const fst = await db.get(k0)
+    const cas = (lst, nxt) => Buffer.compare(lst.value, v0) !== 0
+    await db.del(key, { cas })
+    const snd = await db.get(k0)
+    t.deepEquals(fst, snd)
+    t.notEquals(snd, null)
+  }
+})
+
+tape('bee.batch({ cas }) succeds if cas(last, tomb) returns truthy', async t => {
+  const key = 'key'
+  const value = 'value'
+
+  {
+    const bee = create()
+    const db = bee.batch()
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const cas = (lst) => lst.value === value
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+    t.equals(snd, null)
   }
 
   {
     const bee = create()
     const db = bee.batch()
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const cas = (lst) => lst.value !== value
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+    t.notEquals(snd, null)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const db = bee.batch()
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const cas = (lst) => lst.value === value
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+    t.equals(snd, null)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const db = bee.batch()
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const cas = (lst) => lst.value !== value
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+    t.notEquals(snd, null)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const db = bee.batch()
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const cas = (lst) => JSON.stringify(lst.value) === JSON.stringify(v)
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+    t.equals(snd, null)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const db = bee.batch()
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const cas = (lst) => JSON.stringify(lst.value) !== JSON.stringify(v)
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+    t.notEquals(snd, null)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const db = bee.batch()
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const cas = (lst) => JSON.stringify(lst.value) === JSON.stringify(v)
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.notDeepEquals(fst, snd)
+    t.equals(snd, null)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const db = bee.batch()
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const cas = (lst) => JSON.stringify(lst.value) !== JSON.stringify(v)
+    await db.del(key, { cas })
+    const snd = await db.get(key)
+    t.deepEquals(fst, snd)
+    t.notEquals(snd, null)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'binary' })
+    const db = bee.batch()
     const k0 = Buffer.from(key)
     const v0 = Buffer.from(value)
     await db.put(k0, v0)
     const fst = await db.get(k0)
-    const snd = await db.cas(k0, v0, Buffer.from(value + '^'))
-    await db.flush()
-    t.equals(snd, null)
+    const cas = (lst, nxt) => Buffer.compare(lst.value, v0) === 0
+    await db.del(key, { cas })
+    const snd = await db.get(k0)
     t.notDeepEquals(fst, snd)
+    t.equals(snd, null)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'binary' })
+    const db = bee.batch()
+    const k0 = Buffer.from(key)
+    const v0 = Buffer.from(value)
+    await db.put(k0, v0)
+    const fst = await db.get(k0)
+    const cas = (lst, nxt) => Buffer.compare(lst.value, v0) !== 0
+    await db.del(key, { cas })
+    const snd = await db.get(k0)
+    t.deepEquals(fst, snd)
+    t.notEquals(snd, null)
   }
 })

--- a/test/cas.js
+++ b/test/cas.js
@@ -1,7 +1,7 @@
 const tape = require('tape')
 const { create } = require('./helpers')
 
-tape('cas should put kv pair if comparator evals true, noop otherwise', async t => {
+tape('bee.cas should put kv pair if comparator evals true, noop otherwise', async t => {
   const key = 'key'
   const value = 'value'
 
@@ -98,6 +98,128 @@ tape('cas should put kv pair if comparator evals true, noop otherwise', async t 
     await db.put(k0, v0)
     const fst = await db.get(k0)
     const snd = await db.cas(k0, v0, Buffer.from(value + '^'))
+    t.equals(snd, null)
+    t.notDeepEquals(fst, snd)
+  }
+})
+
+tape('bee.batch().cas() should put kv pair if comparator evals true, noop otherwise', async t => {
+  const key = 'key'
+  const value = 'value'
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const db = bee.batch()
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, value + '^', value)
+    await db.flush()
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const db = bee.batch()
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, value, value + '^')
+    await db.flush()
+    t.equals(snd, null)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const db = bee.batch()
+    const compare = (x, y) => x === y
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, value + '^', value, { compare })
+    await db.flush()
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'utf8' })
+    const db = bee.batch()
+    const compare = (x, y) => x === y
+    await db.put(key, value)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, value, value + '^', { compare })
+    await db.flush()
+    t.equals(snd, null)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const db = bee.batch()
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, { value: value + '^' }, v)
+    await db.flush()
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const db = bee.batch()
+    const v = { value }
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, v, { value: value + '^' })
+    await db.flush()
+    t.equals(snd, null)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const db = bee.batch()
+    const v = { value }
+    const compare = (x, y) => JSON.stringify(x) === JSON.stringify(y)
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, { value: value + '^' }, v, { compare })
+    await db.flush()
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const bee = create({ keyEncoding: 'utf8', valueEncoding: 'json' })
+    const db = bee.batch()
+    const v = { value }
+    const compare = (x, y) => JSON.stringify(x) === JSON.stringify(y)
+    await db.put(key, v)
+    const fst = await db.get(key)
+    const snd = await db.cas(key, v, { value: value + '^' }, { compare })
+    await db.flush()
+    t.equals(snd, null)
+    t.notDeepEquals(fst, snd)
+  }
+
+  {
+    const bee = create()
+    const db = bee.batch()
+    const k0 = Buffer.from(key)
+    const v0 = Buffer.from(value)
+    await db.put(k0, v0)
+    const fst = await db.get(k0)
+    const snd = await db.cas(k0, Buffer.from(value + '^'), v0)
+    await db.flush()
+    t.deepEquals(fst, snd)
+  }
+
+  {
+    const bee = create()
+    const db = bee.batch()
+    const k0 = Buffer.from(key)
+    const v0 = Buffer.from(value)
+    await db.put(k0, v0)
+    const fst = await db.get(k0)
+    const snd = await db.cas(k0, v0, Buffer.from(value + '^'))
+    await db.flush()
     t.equals(snd, null)
     t.notDeepEquals(fst, snd)
   }


### PR DESCRIPTION
Adds the ability to compare and swap on a key in a Hyperbee. In particular, if we have:

* a hyperbee: `bee`
* a key: `key`
* a value we want to set: `value`
* the current value in `bee` at `key`: `current`
* a value we want to compare against `current`: `test`
* and a predicate that will compare `test` and the current value in `bee` at `key`: `compare`

Then `Hyperbee.cas()` compares `current` and `test` through `compare` and:

if `true`: sets `key` at `value` in `bee` and returns `current`
if `false`: return `null`

The default `compare` function encodes `test` through `bee.valueEncoding` and compares against the encoded value of `current`.