### PR TITLE
feat: add getOperation([seq])  API

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,16 @@ Current version.
 #### `await db.ready()`
 
 Makes sure internal state is loaded. Call this once before checking the version if you haven't called any of the other APIs.
+
+#### `await db.getOperation(seq)`
+
+Similar to [createHistoryStream](#stream--dbcreatehistorystreamoptions) but returns a single operation at a given sequence.
+
+If the sequence is `0` it will return null, as the first entry is a header and not a part of the tree operations.
+
+If no sequence is given, it will return the last operation.
+
+```js
+await db.getOperation()
+// { seq: 1, key: 'a', value: 'hello', type: 'put' }
+```

--- a/iterators/history.js
+++ b/iterators/history.js
@@ -26,16 +26,11 @@ module.exports = class HistoryIterator {
 
     if (this.reverse) {
       if (this.lt <= 1) return null
-      return final(await this.db.getBlock(--this.lt, this.options))
+      return (await this.db.getBlock(--this.lt, this.options)).operation()
     }
 
-    return final(await this.db.getBlock(this.gte++, this.options))
+    return (await this.db.getBlock(this.gte++, this.options)).operation()
   }
-}
-
-function final (node) {
-  const type = node.isDeletion() ? 'del' : 'put'
-  return { type, ...node.final() }
 }
 
 function gte (opts, version) {

--- a/test/all.js
+++ b/test/all.js
@@ -407,3 +407,15 @@ tape('feed is unwrapped in getter', async t => {
   t.same(feed, db.feed)
   t.end()
 })
+
+tape('getOperation', async t => {
+  const db = create()
+  await db.ready()
+
+  await db.put('hello', 'world')
+  await db.del('hello')
+
+  t.is(await db.getOperation(0), null)
+  t.same(await db.getOperation(1), { type: 'put', seq: 1, key: 'hello', value: 'world' })
+  t.same(await db.getOperation(), { type: 'del', seq: 2, key: 'hello', value: null })
+})


### PR DESCRIPTION
Same as createHistoryStream but without the overhead of creating then
reading a stream to get one operation.

This is useful for example for watching `core.on('append')` then getting the last operation `getOperation()`.
That use-case would be even better if `core.on('append')` passes the sequence as well `core.on('append', seq => {})`.