### PR TITLE
Fixes deadlock bug on `flush` of empty batch after failed `cas`

### DIFF
--- a/index.js
+++ b/index.js
@@ -760,7 +760,7 @@ class Batch {
   }
 
   flush () {
-    if (!this.length) return Promise.resolve()
+    if (!this.length) return Promise.resolve(this.destroy())
     const batch = this.toBlocks()
 
     this.root = null


### PR DESCRIPTION
In a world without cas, it is impossible for a batch to be both mutated AND for the batch to have a length equal to zero; that is, in a cas-less world every batch operation makes progress. Once we introduce cas, it is possible for us to abort an op on a batch. Since batch.flush() always makes progress regardless of batch size, it is possible for flush to return after we bailed from a batch op (bc cas "failed") without releasing the bee lock that is acquired during every batch mutation.

This PR fixes this bug and adds test to detect it in the future.