### PR TITLE
Clarify behavior of `.del()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Get a key, value. If the key does not exist, `null` is returned.
 
 #### `await db.del(key, [options])`
 
-Delete a key
+Delete a key. *Note that this operation does not render the data irretrievable but only indicates to peers that it should be considered deleted.*
 
 Options include:
 


### PR DESCRIPTION
When users see a method like `.delete()` or `.remove()`, there is a general expectation that the deleted data will be removed from disk and become irretrievable to other peers and clients. As this is not the case, due to the complexities of using an append-only log, the readme should include a clarifying disclaimer indicating the actual behavior.