### PR TITLE
Await this.feed.ready() in bee.get()

### DIFF
--- a/index.js
+++ b/index.js
@@ -396,6 +396,7 @@ class Hyperbee {
   }
 
   async get (key, opts) {
+    await this.feed.ready()
     const snap = this.feed.snapshot()
     const b = new Batch(this, snap, null, true, opts)
     const block = await b.get(key)


### PR DESCRIPTION
This is a bit obscure, but in browsers, if I try to `bee.get(0)` before `bee.ready()`, it throws:
```js
index.js:287 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'defaultAuth')
    at Hypercore._openSession (index.js:287:43)
```

Probably there is something deeper that needs to be fixed about `hypercore._opening` in browser, but this seems to be a fairly safe step to add anyway, and it _does_ solve the problem.

This is even more useful for Hyperdrive, since `drive.get()` implicitly is equivalent to `bee.update(); bee.get()`, so this change enables `drive.get()` without `drive.ready()` first.... in browsers at least!

Environment:

Simple web [example](https://github.com/synonymdev/slashtags/tree/master/examples/browser) built with `parcel`
