### PR TITLE
Support key/value encodings in Batch.put/Batch.get

### DIFF
--- a/index.js
+++ b/index.js
@@ -498,9 +498,10 @@ class Batch {
   }
 
   _getEncoding (opts) {
+    if (!opts) return this.encoding
     return {
-      key: opts && opts.keyEncoding ? codecs(opts.keyEncoding) : this.encoding.key,
-      value: opts && opts.valueEncoding ? codecs(opts.valueEncoding) : this.encoding.value
+      key: opts.keyEncoding ? codecs(opts.keyEncoding) : this.encoding.key,
+      value: opts.valueEncoding ? codecs(opts.valueEncoding) : this.encoding.value
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -548,27 +548,29 @@ class Batch {
 
   async put (key, value, opts) {
     const release = this.batchLock ? await this.batchLock() : null
-    const cas = (opts && opts.cas) || null
 
     if (!this.locked) await this.lock()
-    if (!release) return this._put(key, value, cas)
+    if (!release) return this._put(key, value, opts)
 
     try {
-      return await this._put(key, value, cas)
+      return await this._put(key, value, opts)
     } finally {
       release()
     }
   }
 
-  async _put (key, value, cas) {
+  async _put (key, value, opts) {
+    const cas = (opts && opts.cas) || null
+    const keyEncoding = opts && opts.keyEncoding ? codecs(opts.keyEncoding) : this.keyEncoding
+    const valueEncoding = opts && opts.valueEncoding ? codecs(opts.valueEncoding) : this.valueEncoding
+
     const newNode = {
       seq: 0,
       key,
       value
     }
-
-    key = enc(this.keyEncoding, key)
-    value = enc(this.valueEncoding, value)
+    key = enc(keyEncoding, key)
+    value = enc(valueEncoding, value)
 
     const stack = []
 

--- a/index.js
+++ b/index.js
@@ -243,8 +243,8 @@ class BlockEntry {
   final (encoding) {
     return {
       seq: this.seq,
-      key: encoding && encoding.key ? encoding.key.decode(this.key) : this.key,
-      value: this.value && (encoding && encoding.value ? encoding.value.decode(this.value) : this.value)
+      key: encoding.key ? encoding.key.decode(this.key) : this.key,
+      value: this.value && (encoding.value ? encoding.value.decode(this.value) : this.value)
     }
   }
 
@@ -337,7 +337,7 @@ class Hyperbee {
       opts = encRange(keyEncoding, { ...opts, sub: this._sub })
     }
 
-    const ite = new RangeIterator(new Batch(this, this.feed.snapshot(), null, false, opts), opts)
+    const ite = new RangeIterator(new Batch(this, this.feed.snapshot(), null, false, opts), null, opts)
     return ite
   }
 
@@ -510,7 +510,7 @@ class Batch {
 
   createRangeIterator (opts = {}) {
     const encoding = this._getEncoding(opts)
-    return new RangeIterator(this, encRange(encoding.key, { ...opts, sub: this.tree._sub, encoding }))
+    return new RangeIterator(this, encoding, encRange(encoding.key, { ...opts, sub: this.tree._sub }))
   }
 
   createReadStream (opts) {

--- a/iterators/diff.js
+++ b/iterators/diff.js
@@ -74,6 +74,7 @@ class TreeIterator {
     this.gt = opts.gt || opts.gte || null
     this.gte = !!opts.gte
     this.seeking = !!this.gt
+    this.encoding = opts.encoding || batch.encoding
   }
 
   async open () {
@@ -107,10 +108,10 @@ class TreeIterator {
   async nextKey () {
     let n = null
     while (this.stack.length && n === null) n = await this.next()
-    if (!this.lt) return n.final()
+    if (!this.lt) return n.final(this.encoding)
 
     const c = cmp(n.key, this.lt)
-    if (this.lte ? c <= 0 : c < 0) return n.final()
+    if (this.lte ? c <= 0 : c < 0) return n.final(this.encoding)
     this.stack = []
     return null
   }

--- a/iterators/history.js
+++ b/iterators/history.js
@@ -7,6 +7,7 @@ module.exports = class HistoryIterator {
     this.lt = 0
     this.reverse = !!opts.reverse
     this.limit = typeof opts.limit === 'number' ? opts.limit : -1
+    this.encoding = opts.encoding || batch.encoding
     if (this.live && this.reverse) {
       throw new Error('Cannot have both live and reverse enabled')
     }
@@ -26,10 +27,10 @@ module.exports = class HistoryIterator {
 
     if (this.reverse) {
       if (this.lt <= 1) return null
-      return final(await this.batch.getBlock(--this.lt, this.options))
+      return final(await this.batch.getBlock(--this.lt, this.options), this.encoding)
     }
 
-    return final(await this.batch.getBlock(this.gte++, this.options))
+    return final(await this.batch.getBlock(this.gte++, this.options), this.encoding)
   }
 
   close () {
@@ -37,9 +38,9 @@ module.exports = class HistoryIterator {
   }
 }
 
-function final (node) {
+function final (node, encoding) {
   const type = node.isDeletion() ? 'del' : 'put'
-  return { type, ...node.final() }
+  return { type, ...node.final(encoding) }
 }
 
 function gte (opts, version) {

--- a/iterators/range.js
+++ b/iterators/range.js
@@ -1,12 +1,12 @@
 const b4a = require('b4a')
 
 module.exports = class RangeIterator {
-  constructor (batch, opts = {}) {
+  constructor (batch, encoding, opts = {}) {
     this.batch = batch
     this.stack = []
     this.opened = false
+    this.encoding = encoding || batch.encoding
 
-    this._encoding = opts.encoding || batch.encoding
     this._limit = typeof opts.limit === 'number' ? opts.limit : -1
     this._gIncl = !opts.gt
     this._gKey = opts.gt || opts.gte || null
@@ -154,7 +154,7 @@ module.exports = class RangeIterator {
       }
       if (this._limit > 0) this._limit--
       this._nexting = false
-      return block.final(this._encoding)
+      return block.final(this.encoding)
     }
 
     this._nexting = false

--- a/iterators/range.js
+++ b/iterators/range.js
@@ -6,6 +6,7 @@ module.exports = class RangeIterator {
     this.stack = []
     this.opened = false
 
+    this._encoding = opts.encoding || batch.encoding
     this._limit = typeof opts.limit === 'number' ? opts.limit : -1
     this._gIncl = !opts.gt
     this._gKey = opts.gt || opts.gte || null
@@ -153,7 +154,7 @@ module.exports = class RangeIterator {
       }
       if (this._limit > 0) this._limit--
       this._nexting = false
-      return block.final()
+      return block.final(this._encoding)
     }
 
     this._nexting = false

--- a/test/batches.js
+++ b/test/batches.js
@@ -182,3 +182,23 @@ test('batches can survive parallel ops', async function (t) {
   const all = await collect(db.createReadStream())
   t.alike(all, expected)
 })
+
+test.solo('batch puts support custom key/value encodings', async function (t) {
+  const db = create()
+
+  const b = db.batch()
+  await b.put({ a: 1 }, { b: 2 }, {
+    keyEncoding: 'json',
+    valueEncoding: 'json'
+  })
+  await b.flush()
+
+  const all = await collect(db.createReadStream({
+    keyEncoding: 'json',
+    valueEncoding: 'json'
+  }))
+
+  t.alike(all, [
+    { seq: 1, key: { a: 1 }, value: { b: 2 } }
+  ])
+})

--- a/test/batches.js
+++ b/test/batches.js
@@ -191,6 +191,12 @@ test('batch puts support custom key/value encodings', async function (t) {
     keyEncoding: 'json',
     valueEncoding: 'json'
   })
+  const node = await b.get({ a: 1 }, {
+    keyEncoding: 'json',
+    valueEncoding: 'json'
+  })
+  t.alike(node.key, { a: 1 })
+  t.alike(node.value, { b: 2 })
   await b.flush()
 
   const all = await collect(db.createReadStream({

--- a/test/batches.js
+++ b/test/batches.js
@@ -208,3 +208,43 @@ test('batch puts support custom key/value encodings', async function (t) {
     { seq: 1, key: { a: 1 }, value: { b: 2 } }
   ])
 })
+
+test('batch del supports custom key encodings', async function (t) {
+  const db = create()
+
+  const b = db.batch()
+  await b.put({ a: 1 }, { b: 2 }, {
+    keyEncoding: 'json',
+    valueEncoding: 'json'
+  })
+  await b.del({ a: 1 }, {
+    keyEncoding: 'json'
+  })
+  t.absent(await b.get({ a: 1 }, {
+    keyEncoding: 'json'
+  }))
+})
+
+test('batch createRangeIterator supports custom key/value encodings', async function (t) {
+  const db = create()
+
+  const b = db.batch()
+  await b.put({ a: 1 }, { b: 2 }, {
+    keyEncoding: 'json',
+    valueEncoding: 'json'
+  })
+  await b.put({ a: 3 }, { b: 4 }, {
+    keyEncoding: 'json',
+    valueEncoding: 'json'
+  })
+
+  const all = await collect(b.createReadStream({
+    keyEncoding: 'json',
+    valueEncoding: 'json'
+  }))
+
+  t.alike(all, [
+    { seq: 1, key: { a: 1 }, value: { b: 2 } },
+    { seq: 2, key: { a: 3 }, value: { b: 4 } }
+  ])
+})

--- a/test/batches.js
+++ b/test/batches.js
@@ -183,7 +183,7 @@ test('batches can survive parallel ops', async function (t) {
   t.alike(all, expected)
 })
 
-test.solo('batch puts support custom key/value encodings', async function (t) {
+test('batch puts support custom key/value encodings', async function (t) {
   const db = create()
 
   const b = db.batch()


### PR DESCRIPTION
`Batch.put` and `Batch.get` will both currently use the Batch's default key/value encodings always. This PR lets that be overridden.

Edit: Also added support for custom key encodings to `Batch.del` and `Batch.createReadStream`